### PR TITLE
common package slicerjob defining Job type for both client and server

### DIFF
--- a/slicerjob/slicerjob.go
+++ b/slicerjob/slicerjob.go
@@ -1,10 +1,6 @@
 package slicerjob
 
-import (
-	"fmt"
-
-	"code.google.com/p/go-uuid/uuid"
-)
+import "code.google.com/p/go-uuid/uuid"
 
 type Job struct {
 	ID       string  `json:"id"`
@@ -17,11 +13,8 @@ type Job struct {
 // New creates a new Job with a random UUID for an ID.  If urlformat is
 // non-empty the URL of the returned job is computed as
 // fmt.Sprintf(urlformat,job.ID).
-func New(urlformat string) *Job {
+func New() *Job {
 	job := new(Job)
 	job.ID = uuid.New()
-	if urlformat != "" {
-		job.URL = fmt.Sprintf(urlformat, job.ID)
-	}
 	return job
 }

--- a/slicerjob/slicerjob_test.go
+++ b/slicerjob/slicerjob_test.go
@@ -3,16 +3,8 @@ package slicerjob
 import "testing"
 
 func TestSlicerJob(t *testing.T) {
-	job := New("")
+	job := New()
 	if job.ID == "" {
 		t.Fatalf("new job missing ID")
-	}
-
-	job = New("http://example.com/slicer/jobs/%d")
-	if job.ID == "" {
-		t.Fatalf("new job missing ID")
-	}
-	if job.URL == "" {
-		t.Fatalf("new job supplied with urlformat is missing URL")
 	}
 }


### PR DESCRIPTION
Just defining the struct we will use for the response from the initial `POST /slicer/jobs` request, and subsequent polling requests `GET /slicer/jobs/{id}`.
